### PR TITLE
Fixing issue where magic file matching too loose

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -37,7 +37,7 @@ find "$owndir"/autoformat -type f $FIND_ARGS | {
         # file’s libmagic output matches
         match_magic=''
         [ $match_pattern ] || {
-          [ -f "$magic" ] && file "$orig" | grep -Eqif "$magic" && match_magic='1'
+          [ -f "$magic" ] && file -b "$orig" | grep -Eqif "$magic" && match_magic='1'
         }
 
         # if none, ignore


### PR DESCRIPTION
When `file` returns its output, it generally will return the name
of the file along with its results for file contents.  This would
cause files named something like `XmlParser.java` to be counted
as XML files, and be parsed to the xmllint formatter.  Adding the
`-b` flag tells `file` to print a brief output, which does not
echo out the file name, just the results for file contents.