### PR TITLE
Windows path separator fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ What's left is to symlink `$PROJECT/.git/hooks` to `$PROJECT/git-hooks`:
 
 **IMPORTANT**: this linking step **has to** be done **manually** by **every developer**.
 
+**IMPORTANT**: for **Windows** users, due to limitations on Windows shell emulators, links seem to be implemented more often than not as 'copy', so any time the git-hooks directory is updated, the linking step needs to be re-done.
+
 The usual workflow then is:
 
 1. Modify some files.

--- a/tools/eclipse-java-formatter/ejf
+++ b/tools/eclipse-java-formatter/ejf
@@ -16,7 +16,13 @@ cat "$d/lib/sources.list" | grep -Ev '^\s*(#|$)' | while IFS= read -r url ; do
   fi
 done
 
-lib_classpath="$(find "$d/lib/" -name '*.jar' | tr '\n' ':')"
+os="$(uname -s)"
+case "${os}" in
+  CYGWIN*)	sep=";";;
+  *)		sep=":";;
+esac
+
+lib_classpath="$(find "$d/lib/" -name '*.jar' | tr '\n' $sep)"
 
 src="$d/src/ejf/Main.java"
 bin="$d/bin"
@@ -29,4 +35,4 @@ fi
 
 style="$(find "$d/lib/" -name '*.xml' | head -n 1)"
 
-java -cp "$lib_classpath:$bin" ejf.Main "$style" "$@"
+java -cp "$lib_classpath$bin" ejf.Main "$style" "$@"


### PR DESCRIPTION
Fixing the issue with path separators for Windows users.

Also added some info to the README for Windows users and how linking the git-hooks directory to .git/hooks is not as useful as it could be...