### PR TITLE
Allow to symlink only the pre-commit script in hooks

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -3,7 +3,7 @@
 root="$(git rev-parse --show-toplevel)"
 [ -d "$root" ] || exit 1
 
-owndir="$(cd "$(dirname "$0")"; pwd -P)"
+owndir="$(dirname "$(readlink -f "$0")")"
 
 OS_NAME=$(uname)
 


### PR DESCRIPTION
 and not the whole hooks directory.

ln -s ../git-hooks .git/hooks
ln -s ../git-hooks/pre-commit .git/hooks/pre-commit


#17 